### PR TITLE
feat(safe-wallet): implement transfer with policy enforcement (#2)

### DIFF
--- a/contracts/safe-wallet/src/lib.rs
+++ b/contracts/safe-wallet/src/lib.rs
@@ -2,7 +2,7 @@
 
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype,
-    Address, Env, Vec,
+    token, Address, Env, Vec,
 };
 
 // ---------------------------------------------------------------------------
@@ -19,6 +19,7 @@ pub enum DataKey {
     Whitelist,
     RecoveryKey,
     Frozen,
+    TokenAddress,
 }
 
 // ---------------------------------------------------------------------------
@@ -64,6 +65,13 @@ impl SafeWallet {
             .set(&DataKey::LastResetTimestamp, &env.ledger().timestamp());
     }
 
+    /// Set the token contract address used for transfers. Owner only.
+    pub fn set_token_address(env: Env, token: Address) -> Result<(), WalletError> {
+        Self::require_owner(&env)?;
+        env.storage().instance().set(&DataKey::TokenAddress, &token);
+        Ok(())
+    }
+
     /// Add an address to the whitelist.
     pub fn add_whitelist(env: Env, address: Address) -> Result<(), WalletError> {
         Self::require_owner(&env)?;
@@ -74,6 +82,72 @@ impl SafeWallet {
             .unwrap_or_else(|| Vec::new(&env));
         list.push_back(address);
         env.storage().instance().set(&DataKey::Whitelist, &list);
+        Ok(())
+    }
+
+    /// Transfer tokens to a whitelisted address, enforcing owner auth,
+    /// wallet freeze state, and daily spending cap.
+    pub fn transfer(env: Env, to: Address, amount: i128) -> Result<(), WalletError> {
+        Self::require_owner(&env)?;
+
+        if Self::is_frozen(env.clone()) {
+            return Err(WalletError::WalletFrozen);
+        }
+
+        if amount <= 0 {
+            return Err(WalletError::ZeroAmount);
+        }
+
+        // Ensure `to` is in the whitelist.
+        let list: Vec<Address> = env
+            .storage()
+            .instance()
+            .get(&DataKey::Whitelist)
+            .unwrap_or_else(|| Vec::new(&env));
+        if !Self::vec_contains(&list, &to) {
+            return Err(WalletError::AddressNotWhitelisted);
+        }
+
+        // Reset daily spend counter if the 24h window has elapsed.
+        let now = env.ledger().timestamp();
+        let last_reset: u64 = env
+            .storage()
+            .instance()
+            .get(&DataKey::LastResetTimestamp)
+            .unwrap_or(now);
+        let spent_today: i128 = if now >= last_reset + 86_400 {
+            env.storage().instance().set(&DataKey::LastResetTimestamp, &now);
+            0_i128
+        } else {
+            env.storage()
+                .instance()
+                .get(&DataKey::SpentToday)
+                .unwrap_or(0_i128)
+        };
+
+        let daily_cap: i128 = env
+            .storage()
+            .instance()
+            .get(&DataKey::DailyCap)
+            .ok_or(WalletError::NotInitialised)?;
+        if spent_today + amount > daily_cap {
+            return Err(WalletError::DailyCapExceeded);
+        }
+
+        // Execute the token transfer.
+        let token_address: Address = env
+            .storage()
+            .instance()
+            .get(&DataKey::TokenAddress)
+            .ok_or(WalletError::NotInitialised)?;
+        let token_client = token::Client::new(&env, &token_address);
+        token_client.transfer(&env.current_contract_address(), &to, &amount);
+
+        // Record spend.
+        env.storage()
+            .instance()
+            .set(&DataKey::SpentToday, &(spent_today + amount));
+
         Ok(())
     }
 
@@ -113,6 +187,17 @@ impl SafeWallet {
         owner.require_auth();
         Ok(owner)
     }
+
+    fn vec_contains(list: &Vec<Address>, target: &Address) -> bool {
+        for i in 0..list.len() {
+            if let Some(item) = list.get(i) {
+                if &item == target {
+                    return true;
+                }
+            }
+        }
+        false
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -130,5 +215,81 @@ mod tests {
         let contract_id = env.register(SafeWallet, ());
         let client = SafeWalletClient::new(&env, &contract_id);
         assert!(!client.is_frozen());
+    }
+
+    #[test]
+    fn test_transfer_fails_when_frozen() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SafeWallet, ());
+        let client = SafeWalletClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let to = Address::generate(&env);
+        client.initialize(&owner, &1000, &recovery);
+        client.add_whitelist(&to);
+        client.freeze(&recovery);
+
+        assert_eq!(
+            client.try_transfer(&to, &100),
+            Err(Ok(WalletError::WalletFrozen))
+        );
+    }
+
+    #[test]
+    fn test_transfer_fails_when_not_whitelisted() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SafeWallet, ());
+        let client = SafeWalletClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let to = Address::generate(&env);
+        client.initialize(&owner, &1000, &recovery);
+
+        assert_eq!(
+            client.try_transfer(&to, &100),
+            Err(Ok(WalletError::AddressNotWhitelisted))
+        );
+    }
+
+    #[test]
+    fn test_transfer_fails_when_exceeds_daily_cap() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SafeWallet, ());
+        let client = SafeWalletClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let to = Address::generate(&env);
+        client.initialize(&owner, &1000, &recovery);
+        client.add_whitelist(&to);
+
+        assert_eq!(
+            client.try_transfer(&to, &1500),
+            Err(Ok(WalletError::DailyCapExceeded))
+        );
+    }
+
+    #[test]
+    fn test_transfer_fails_when_token_not_set() {
+        let env = Env::default();
+        env.mock_all_auths();
+        let contract_id = env.register(SafeWallet, ());
+        let client = SafeWalletClient::new(&env, &contract_id);
+
+        let owner = Address::generate(&env);
+        let recovery = Address::generate(&env);
+        let to = Address::generate(&env);
+        client.initialize(&owner, &1000, &recovery);
+        client.add_whitelist(&to);
+
+        assert_eq!(
+            client.try_transfer(&to, &100),
+            Err(Ok(WalletError::NotInitialised))
+        );
     }
 }


### PR DESCRIPTION
Closes #2

Implements 	ransfer(env, to, amount) with all policy enforcement from the issue acceptance criteria:

- Owner auth via equire_owner`n- Frozen-wallet rejection
- Whitelist check for the destination address
- Daily-spend reset when the 24h window elapses
- Daily-cap enforcement
- Token contract transfer via 	oken::Client`n- SpentToday update after success

Also adds set_token_address(env, token) so the owner can configure the token contract used for outgoing transfers. This keeps the requested 	ransfer signature unchanged while providing the missing token-contract dependency.

Includes unit tests for:
- Transfer rejected when wallet is frozen
- Transfer rejected when destination is not whitelisted
- Transfer rejected when amount exceeds daily cap
- Transfer rejected when no token address has been configured
