### PR TITLE
feat(scripts): add testnet deployment script (#7)

### DIFF
--- a/docs/policies.md
+++ b/docs/policies.md
@@ -1,0 +1,204 @@
+# Spending Policies
+
+This guide explains how Soroban Safe enforces spending policies on Stellar. It is intended for wallet owners, integrators, and contributors who want to understand the policy engine without reading the contract source.
+
+## Overview
+
+Soroban Safe uses a small set of on-chain policy controls that are evaluated on every transfer:
+
+| Policy | Purpose |
+|---|---|
+| **Daily cap** | Limit total outflows in a rolling 24-hour window |
+| **Whitelist** | Restrict transfers to approved recipient addresses |
+| **Freeze/unfreeze** | Halt all outflows in an emergency |
+| **Recovery key** | A separate key that can freeze the wallet if the owner key is compromised |
+
+These policies are stored in the wallet's instance storage and are checked by the `transfer` entrypoint before any token movement.
+
+---
+
+## Daily Cap
+
+The daily cap is the maximum amount the wallet can transfer within a rolling 24-hour window. It is set during `initialize` and is denominated in **stroops** (1 XLM = 10,000,000 stroops).
+
+### How it works
+
+1. Each wallet stores `DailyCap`, `SpentToday`, and `LastResetTimestamp`.
+2. Before a transfer, the contract checks whether the current ledger timestamp has moved past `LastResetTimestamp + 24 hours`.
+3. If the window has rolled over, `SpentToday` is reset to `0` and `LastResetTimestamp` is updated.
+4. The requested amount is added to `SpentToday` and compared against `DailyCap`.
+5. If the new total would exceed the cap, the transfer returns `WalletError::DailyCapExceeded`.
+
+### Example
+
+```bash
+# Initialize a wallet with a 100 XLM daily cap
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source owner \
+  --network testnet \
+  -- \
+  initialize \
+  --owner <OWNER_ADDRESS> \
+  --daily_cap 1000000000 \
+  --recovery_key <RECOVERY_ADDRESS>
+```
+
+```rust
+// Rust SDK example
+use soroban_sdk::{Address, Env};
+
+let client = SafeWalletClient::new(&env, &contract_id);
+client.initialize(
+    &owner_address,      // Address
+    &100_000_0000i128,   // 100 XLM daily cap in stroops
+    &recovery_address,    // Address
+);
+```
+
+---
+
+## Whitelist
+
+The whitelist is a list of `Address` values that are allowed to receive transfers. If the wallet is initialized with a non-empty whitelist (or one is added later), every `transfer` recipient must be present in the list.
+
+### Managing the whitelist
+
+Only the wallet owner can add or remove addresses.
+
+```bash
+# Add a recipient to the whitelist
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source owner \
+  --network testnet \
+  -- \
+  add_whitelist \
+  --address <RECIPIENT_ADDRESS>
+```
+
+```rust
+// Rust SDK example
+client.add_whitelist(&recipient_address);
+```
+
+A transfer to an address that is not on the whitelist returns `WalletError::AddressNotWhitelisted`.
+
+### When to use the whitelist
+
+- Restrict payroll or treasury outflows to known counter-parties.
+- Reduce blast radius if the owner key is used without approval.
+- Enforce vendor lists in multi-user organizations.
+
+---
+
+## Freeze and Unfreeze
+
+The wallet can be frozen by the recovery key. While frozen, all transfers are rejected with `WalletError::WalletFrozen`. The owner can still read state, but no outflows are possible.
+
+### Freeze flow
+
+1. The recovery key calls `freeze(caller)`.
+2. The contract verifies that `caller == RecoveryKey`.
+3. `Frozen` is set to `true`.
+
+```bash
+# Freeze the wallet from the recovery key
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source recovery \
+  --network testnet \
+  -- \
+  freeze \
+  --caller <RECOVERY_ADDRESS>
+```
+
+```rust
+// Rust SDK example
+client.freeze(&recovery_address);
+```
+
+### Unfreeze
+
+Unfreezing is an owner-only operation. The owner calls `unfreeze()` to set `Frozen` back to `false` and resume normal transfers.
+
+```bash
+# Unfreeze the wallet (owner only)
+stellar contract invoke \
+  --id <CONTRACT_ID> \
+  --source owner \
+  --network testnet \
+  -- \
+  unfreeze
+```
+
+```rust
+// Rust SDK example
+client.unfreeze();
+```
+
+### When to freeze
+
+- The owner key is suspected to be compromised.
+- Unusual spending patterns are detected off-chain.
+- A security incident requires an immediate circuit breaker.
+
+---
+
+## Recovery Key
+
+The recovery key is a separate `Address` set during `initialize`. It has only one power: **freezing the wallet**. It cannot transfer funds, change the daily cap, or modify the whitelist.
+
+### Responsibilities
+
+- Store the recovery key in a different location or with a different custodian than the owner key.
+- Use it only in emergencies.
+- After freezing, coordinate with the owner to rotate keys or investigate before unfreezing.
+
+### Why a separate key?
+
+If the owner and recovery keys were the same, a compromised owner key could both steal funds and prevent anyone from stopping the theft. Splitting the roles means an attacker who owns the owner key still cannot prevent the recovery key from freezing the wallet.
+
+---
+
+## Transfer Enforcement Summary
+
+The following checks are applied in order on every `transfer`:
+
+1. **Owner authorization** — `owner.require_auth()`.
+2. **Frozen state** — reject if `Frozen == true`.
+3. **Whitelist** — reject if a whitelist exists and the recipient is not on it.
+4. **Daily window reset** — roll `SpentToday` forward if 24 hours have passed.
+5. **Daily cap** — reject if `SpentToday + amount > DailyCap`.
+6. **Execute transfer** — move tokens to the recipient and increment `SpentToday`.
+
+```text
+transfer(to, amount)
+  ├─ require owner auth
+  ├─ check !frozen
+  ├─ check to ∈ whitelist (if whitelist is set)
+  ├─ maybe reset daily window
+  ├─ check spent + amount ≤ daily_cap
+  └─ execute token transfer
+```
+
+---
+
+## Error Reference
+
+| Error | Cause |
+|---|---|
+| `Unauthorized` | Caller is not the owner or recovery key for the requested operation. |
+| `DailyCapExceeded` | Transfer would exceed the rolling 24-hour cap. |
+| `AddressNotWhitelisted` | Recipient is not in the whitelist. |
+| `WalletFrozen` | Wallet is frozen and no transfers are allowed. |
+| `ZeroAmount` | Transfer amount is zero or negative. |
+| `NotInitialised` | Wallet storage has not been initialized yet. |
+
+---
+
+## See Also
+
+- [`architecture.md`](architecture.md) — contract layout and storage keys
+- [`deployment.md`](deployment.md) — how to deploy the wallet to Testnet/Mainnet
+- [`CONTRIBUTING.md`](../CONTRIBUTING.md) — contribution guidelines

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+#
+# Deploy the SafeWallet and Airdrop contracts to Stellar Testnet (or another network).
+#
+# Usage:
+#   ./scripts/deploy.sh [--network <network-name>]
+#
+# Defaults:
+#   --network testnet
+#
+# The script is idempotent for network configuration and key generation: running it
+# multiple times with the same network will not create duplicates.
+
+set -euo pipefail
+
+NETWORK="testnet"
+DEPLOYER_KEY="deployer"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --network)
+      NETWORK="$2"
+      shift 2
+      ;;
+    --help|-h)
+      echo "Usage: $0 [--network <network-name>]"
+      exit 0
+      ;;
+    *)
+      echo "Unknown option: $1"
+      echo "Usage: $0 [--network <network-name>]"
+      exit 1
+      ;;
+  esac
+done
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Network configuration for known networks.
+RPC_URL=""
+PASSPHRASE=""
+case "$NETWORK" in
+  testnet)
+    RPC_URL="https://soroban-testnet.stellar.org"
+    PASSPHRASE="Test SDF Network ; September 2015"
+    ;;
+  futurenet)
+    RPC_URL="https://rpc-futurenet.stellar.org"
+    PASSPHRASE="Test SDF Future Network ; October 2022"
+    ;;
+  *)
+    echo "Unknown network '$NETWORK'. Please configure it manually with:"
+    echo "  stellar network add $NETWORK --rpc-url <url> --network-passphrase <passphrase>"
+    exit 1
+    ;;
+esac
+
+# Ensure the Stellar CLI is available.
+if ! command -v stellar >/dev/null 2>&1; then
+  echo "Error: stellar CLI not found. Install it from https://developers.stellar.org/docs/tools/developer-tools/stellar-cli"
+  exit 1
+fi
+
+# Add the network if it is not already configured (idempotent).
+if ! stellar network ls | grep -qx "$NETWORK"; then
+  echo "Configuring Stellar network: $NETWORK"
+  stellar network add "$NETWORK" \
+    --rpc-url "$RPC_URL" \
+    --network-passphrase "$PASSPHRASE"
+else
+  echo "Network '$NETWORK' already configured."
+fi
+
+# Generate the deployer key if it does not exist (idempotent).
+if ! stellar keys ls | grep -qx "$DEPLOYER_KEY"; then
+  echo "Generating deployer key: $DEPLOYER_KEY"
+  stellar keys generate "$DEPLOYER_KEY" --network "$NETWORK"
+else
+  echo "Deployer key '$DEPLOYER_KEY' already exists."
+fi
+
+# Fund the deployer account. Friendbot only works on testnet/futurenet.
+echo "Funding deployer account via friendbot..."
+stellar keys fund "$DEPLOYER_KEY" --network "$NETWORK" || echo "Friendbot funding skipped or account already funded."
+
+# Build the contracts.
+echo "Building contracts..."
+cd "$PROJECT_ROOT"
+cargo build --target wasm32-unknown-unknown --release
+
+SAFE_WALLET_WASM="$PROJECT_ROOT/target/wasm32-unknown-unknown/release/safe_wallet.wasm"
+AIRDROP_WASM="$PROJECT_ROOT/target/wasm32-unknown-unknown/release/airdrop.wasm"
+
+if [[ ! -f "$SAFE_WALLET_WASM" ]]; then
+  echo "Error: safe_wallet.wasm not found at $SAFE_WALLET_WASM"
+  exit 1
+fi
+if [[ ! -f "$AIRDROP_WASM" ]]; then
+  echo "Error: airdrop.wasm not found at $AIRDROP_WASM"
+  exit 1
+fi
+
+# Deploy contracts and capture contract IDs.
+echo "Deploying SafeWallet contract..."
+SAFE_WALLET_ID=$(stellar contract deploy \
+  --wasm "$SAFE_WALLET_WASM" \
+  --source "$DEPLOYER_KEY" \
+  --network "$NETWORK" \
+  --alias safe-wallet)
+
+echo "Deploying Airdrop contract..."
+AIRDROP_ID=$(stellar contract deploy \
+  --wasm "$AIRDROP_WASM" \
+  --source "$DEPLOYER_KEY" \
+  --network "$NETWORK" \
+  --alias airdrop)
+
+echo ""
+echo "========================================"
+echo "Deployment complete on network: $NETWORK"
+echo "SafeWallet contract ID: $SAFE_WALLET_ID"
+echo "Airdrop contract ID:    $AIRDROP_ID"
+echo "========================================"


### PR DESCRIPTION
Closes #7

Adds scripts/deploy.sh to automate testnet deployment of both SafeWallet and Airdrop contracts.

What it does:
- Configures the 	estnet Stellar network idempotently (also supports uturenet via --network).
- Generates a deployer key if one does not exist.
- Funds the deployer via friendbot.
- Builds both safe-wallet and irdrop contracts to wasm32-unknown-unknown.
- Deploys both contracts and prints their contract IDs.
- Accepts an optional --network flag (defaults to 	estnet).

The script is executable and includes usage comments at the top.